### PR TITLE
Memory usage and performance optimizations

### DIFF
--- a/rcs-fast-export.rb
+++ b/rcs-fast-export.rb
@@ -461,7 +461,7 @@ module RCS
 						end
 					end
 				when :desc
-					rcs.desc.replace lines.dup
+					rcs.desc.replace lines
 					status.pop
 				when :read_lines
 					# we sanitize lines as we read them
@@ -541,13 +541,13 @@ module RCS
 						status.pop
 					end
 				when :log
-					rcs.revision[rev].log.replace lines.dup
+					rcs.revision[rev].log.replace lines
 					status.pop
 				when :head
 					if opts[:expand_keywords]
 						rcs.revision[rev].text.replace RCS.expand_keywords(rcsfile, rev)
 					else
-						rcs.revision[rev].text.replace lines.dup
+						rcs.revision[rev].text.replace lines
 					end
 					rcs.revision[rev].text_hash = Digest::SHA256.digest rcs.revision[rev].text.join('')
 					puts rcs.revision[rev].blob
@@ -556,7 +556,7 @@ module RCS
 					if opts[:expand_keywords]
 						rcs.revision[rev].text.replace RCS.expand_keywords(rcsfile, rev)
 					else
-						difflines.replace lines.dup
+						difflines.replace lines
 						difflines.pop if difflines.last.empty?
 						if difflines.first.chomp.empty?
 							alert "malformed diff: empty initial line @ #{rcsfile}:#{file.lineno-difflines.length-1}", "skipping"

--- a/rcs-fast-export.rb
+++ b/rcs-fast-export.rb
@@ -569,8 +569,7 @@ module RCS
 							raise 'no diff base!'
 						end
 						# deep copy
-						buffer = []
-						rcs.revision[base].text.each { |l| buffer << [l.dup] }
+						buffer = rcs.revision[base].text.map { |l| [l] }
 
 						adding = false
 						index = nil

--- a/rcs-fast-export.rb
+++ b/rcs-fast-export.rb
@@ -619,7 +619,6 @@ module RCS
 						end
 
 						# turn the buffer into an array of lines, deleting the empty ones
-						buffer.delete_if { |l| l.empty? }
 						buffer.flatten!
 
 						rcs.revision[rev].text = buffer


### PR DESCRIPTION
The first commit of this series solves that problem, that long RCS histories of large files (nearly 30k revisions resulting in a 4 MB file) requires tremendous amount of memory (200GB RAM were not enough...). The solution is to keep only a hash digest for revisions which will no longer be used for diffing. This way commit coalescing is still possible by using the hash but requires a lot less memory.

The next three changes avoid some unnecessary string and array copies.

This is complemented by applying the diff using a linear scan to avoid lots of small array allocations. This change might be problematic as it introduces the new assumption that a diff always contains incrementing line numbers.