### PR TITLE
Support for extra newlines in TWiki RCS files

### DIFF
--- a/rcs-fast-export.rb
+++ b/rcs-fast-export.rb
@@ -456,6 +456,8 @@ module RCS
 				when :read_lines
 					# we sanitize lines as we read them
 
+					next if lines.empty? && line.chomp.empty?
+
 					actual_line = line.dup
 
 					# the first line must begin with a @, which we strip


### PR DESCRIPTION
This pull request fixes an error which occurs if there is an extra newline after a `node` identifier before the `@` section starts.

This avoid the following error message:

```
Failed to parse xxxx @ xxxx:yy
rcs-fast-export.rb:464:in `block (2 levels) in parse': malformed line
```